### PR TITLE
🛡️ Sentinel: [MEDIUM] Remove stack trace from error response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** GitHub Actions workflows were lacking explicit `permissions` blocks, violating the Principle of Least Privilege.
 **Learning:** Without explicit permissions, the default `GITHUB_TOKEN` might be granted broader access than required (e.g., repository write access), increasing the blast radius if an action is compromised.
 **Prevention:** Always declare explicit, scoped `permissions` (e.g., `contents: read`, `issues: write`) at the top level of every `.yml` workflow file.
+## 2026-04-10 - Stack Trace Leakage in Automation Scripts
+**Vulnerability:** Internal error handling in automation scripts (`scripts/collect_data.py`, `scripts/analyze_outlier.py`, `scripts/generate_chart.py`) was leaking stack traces via `logger.error(..., exc_info=True)` and `traceback.print_exc()`, potentially exposing sensitive internal details in GitHub Actions logs.
+**Learning:** Overly verbose logging designed for debugging during local development was left in production scripts executed in a CI/CD environment, violating the "fail securely" principle.
+**Prevention:** Avoid using `exc_info=True` or `traceback.print_exc()` in non-debug logging contexts, specifically in scripts designed to execute via CI/CD platforms, ensuring error messages are descriptive but do not reveal internal implementation details.

--- a/scripts/analyze_outlier.py
+++ b/scripts/analyze_outlier.py
@@ -51,6 +51,6 @@ if __name__ == "__main__":
             
         logger.info(f"분석 완료: 이상치 여부 = {is_outlier_detected}")
     except Exception as error:
-        logger.error(f"이상치 분석 실패: {error}", exc_info=True)
+        logger.error(f"이상치 분석 실패: {error}")
         print(f"분석 실패: {error}")
         sys.exit(1)

--- a/scripts/collect_data.py
+++ b/scripts/collect_data.py
@@ -79,6 +79,6 @@ if __name__ == "__main__":
             logger.info("오늘 날짜의 데이터가 이미 존재합니다.")
             print("오늘 날짜의 데이터가 이미 존재합니다.")
     except Exception as error:
-        logger.error(f"데이터 수집 실패: {error}", exc_info=True)
+        logger.error(f"데이터 수집 실패: {error}")
         print(f"데이터 수집 실패: {error}")
         sys.exit(1)

--- a/scripts/generate_chart.py
+++ b/scripts/generate_chart.py
@@ -9,7 +9,6 @@
 import sys
 import importlib.util
 from pathlib import Path
-from datetime import datetime, timedelta
 
 # Setup paths
 project_root = Path(__file__).resolve().parent.parent
@@ -55,7 +54,5 @@ if __name__ == "__main__":
             f"성공적으로 {output_chart_image_file}에 저장되었습니다"
         )
     except Exception as chart_generation_error:
-        import traceback
         print(f"시각화 실패: {chart_generation_error}")
-        traceback.print_exc()
         sys.exit(1)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Internal stack traces were being leaked in error logs via `exc_info=True` and `traceback.print_exc()` within the automation scripts (`scripts/collect_data.py`, `scripts/analyze_outlier.py`, `scripts/generate_chart.py`).
🎯 Impact: This could expose sensitive internal implementation details, directory structures, and library internals in GitHub Actions logs when errors occur.
🔧 Fix: Removed `exc_info=True` from logging statements and removed the `traceback` import and usage in error handling to ensure errors fail securely without leaking internal information.
✅ Verification: Ran `uv run pytest tests/` and `uv run python scripts/<script_name>.py` to verify functionality is preserved, and manually confirmed the scripts now log descriptive error messages without printing the stack trace on failure.

---
*PR created automatically by Jules for task [14271744281401824593](https://jules.google.com/task/14271744281401824593) started by @partrita*

## Summary by Sourcery

Harden logging in automation scripts to avoid leaking stack traces while documenting the issue and its remediation in the Sentinel security log.

Enhancements:
- Remove stack trace printing from automation scripts to ensure errors fail securely without exposing internal details in logs.

Documentation:
- Add Sentinel entry describing the stack trace leakage vulnerability in automation scripts and the recommended secure logging practices.