### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF Bypass via Internal Ports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,8 @@
 **Vulnerability:** URL validation using `urlparse` allowed a bypass using the backslash `\` character in the domain (e.g. `https://127.0.0.1\.naver.com/`). `urlparse` treats the backslash as part of the `netloc`, passing domain suffix checks, while HTTP clients like `requests` normalize the `\` to `/`, routing the request to the IP Address `127.0.0.1` instead.
 **Learning:** Checking for specific string suffixes like `.endswith(".naver.com")` after extracting components via `urllib.parse` is prone to bypasses because libraries resolving the request might parse and normalize the input differently than Python's standard `urlparse`.
 **Prevention:** In addition to verifying the domain name suffix, explicitly reject any URLs that contain invalid hostname characters like `@` or `\` in the `netloc`.
+
+## 2026-04-13 - [Security Enhancement] SSRF Bypass via Internal Ports
+**Vulnerability:** URL validation did not check the requested port, allowing potential SSRF bypasses to internal services running on non-standard ports (e.g., Redis on 6379, databases on 5432, custom internal APIs on 8080) if an attacker managed to bypass domain validation.
+**Learning:** Only validating the URL scheme (`https`) and domain is insufficient defense-in-depth, as attackers can specify arbitrary ports to scan or interact with internal infrastructure.
+**Prevention:** Explicitly validate `parsed_url.port` and only permit standard web ports (e.g. `443` or `None` which implies the default for the scheme) during data fetching operations.

--- a/src/kimchi_gold/price_fetcher.py
+++ b/src/kimchi_gold/price_fetcher.py
@@ -74,6 +74,9 @@ def extract_price_from_naver_finance(
     if "\\" in parsed_url.netloc:
         raise ValueError("URL must not contain backslashes (\\)")
 
+    if parsed_url.port not in (None, 443):
+        raise ValueError(f"Invalid port: {parsed_url.port}. Only standard HTTPS port (443) is allowed.")
+
     hostname = parsed_url.hostname or ""
     if not (hostname == "naver.com" or hostname.endswith(".naver.com")):
         raise ValueError(f"Invalid domain: {hostname}. Only naver.com and its subdomains are allowed.")

--- a/tests/test_now_price.py
+++ b/tests/test_now_price.py
@@ -201,3 +201,11 @@ def test_extract_price_ssrf_protection_backslash_bypass():
     with pytest.raises(ValueError) as excinfo:
         price_fetcher.extract_price_from_naver_finance(url, error_msg)
     assert "URL must not contain backslashes" in str(excinfo.value)
+
+
+def test_extract_price_ssrf_protection_invalid_port():
+    url = "https://finance.naver.com:8080/"
+    error_msg = "테스트 에러 메시지"
+    with pytest.raises(ValueError) as excinfo:
+        price_fetcher.extract_price_from_naver_finance(url, error_msg)
+    assert "Invalid port" in str(excinfo.value)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSRF Bypass via Internal Ports. URL validation did not check the requested port, allowing potential SSRF bypasses to internal services running on non-standard ports (e.g., Redis on 6379, databases on 5432, custom internal APIs on 8080) if an attacker managed to bypass domain validation.
🎯 Impact: Attackers could scan or interact with internal infrastructure on non-standard ports.
🔧 Fix: Explicitly validate `parsed_url.port` in `extract_price_from_naver_finance` and only permit standard web ports (e.g. `443` or `None` which implies the default for the scheme) during data fetching operations.
✅ Verification: Ran `uv run pytest tests/` and verified that the newly added test `test_extract_price_ssrf_protection_invalid_port` passes successfully.

---
*PR created automatically by Jules for task [10426009605964836570](https://jules.google.com/task/10426009605964836570) started by @partrita*