### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Input Validation and Length Limits for Price Data

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** Unintended payload processing and Slowloris-style slow-read DoS.
 **Learning:** `requests.get` with `stream=True` and a max size check is vulnerable to slow-read attacks where an attacker sends data extremely slowly, exhausting server resources/connection pools, and missing `Content-Type` validation could lead to parsing non-HTML binary payloads using BeautifulSoup.
 **Prevention:** To prevent unintended payload types and mitigate Slowloris-style slow-read DoS attacks, explicitly validate the `Content-Type` header (e.g., `text/html`) before reading HTTP responses and enforce a strict absolute time limit within the `requests` streaming loop.
+
+## 2026-04-19 - [Security Enhancement] Input Validation and Length Limits for Price Data
+**Vulnerability:** Extracted price data strings were cast to `float` without string length limits, and numerical validation did not account for `NaN`, `Inf`, or unfeasibly large values, posing algorithmic complexity DoS risks (e.g., extremely long float parsing) and data poisoning/logic errors downstream.
+**Learning:** External inputs parsed from HTML, even those matched by a regex, must be strictly bounded in both string length before parsing and numerical range after parsing. Missing NaN/Inf checks on floats can lead to unexpected behavior in financial logic.
+**Prevention:** Implement strict length limits (e.g., 50 characters) on extracted strings before type conversion to prevent long-string processing overhead. Enhance numeric validation to explicitly reject `math.isnan`, `math.isinf`, and logically excessive values (e.g., > 1,000,000,000) to ensure data integrity and prevent downstream errors.

--- a/src/kimchi_gold/price_fetcher.py
+++ b/src/kimchi_gold/price_fetcher.py
@@ -5,6 +5,7 @@
 import re
 import time
 import logging
+import math
 from typing import Tuple
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
@@ -36,11 +37,21 @@ def validate_price(price: float, name: str) -> float:
         검증된 가격 (float)
 
     Raises:
-        ValueError: 가격이 0 이하인 경우 (데이터가 비정상이거나 수집 오류)
+        ValueError: 가격이 0 이하이거나 비정상적인 값인 경우
     """
+    if math.isnan(price) or math.isinf(price):
+        logger.error(f"비정상적인 가격(NaN/Inf) 감지 ({name}): {price}")
+        raise ValueError(f"유효하지 않은 {name} 값입니다. (NaN/Inf)")
+
     if price <= 0:
         logger.error(f"유효하지 않은 가격 감지 ({name}): {price}")
         raise ValueError(f"유효하지 않은 {name} 값입니다. (0 이하)")
+
+    # 10억 이상의 가격은 비정상으로 간주 (단위 변경이나 파싱 오류 방지)
+    if price > 1_000_000_000:
+        logger.error(f"비정상적으로 큰 가격 감지 ({name}): {price}")
+        raise ValueError(f"유효하지 않은 {name} 값입니다. (비정상적으로 큰 값)")
+
     return price
 
 
@@ -121,7 +132,11 @@ def extract_price_from_naver_finance(
         text = price_tag.get_text()
         price_match = re.search(price_pattern, text)
         if price_match:
-            extracted_price = float(price_match.group().replace(",", ""))
+            matched_string = price_match.group().replace(",", "")
+            # Security Enhancement: Prevent algorithmic complexity DoS by limiting string length before float()
+            if len(matched_string) > 50:
+                raise ValueError("추출된 가격 문자열이 너무 깁니다. (DoS 방지)")
+            extracted_price = float(matched_string)
             return validate_price(extracted_price, error_message.split(" ")[0])
     raise ValueError(error_message)
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Algorithmic complexity DoS risks (e.g., extremely long float parsing) and data poisoning downstream due to unchecked string lengths and `NaN`/`Inf` bypasses in price scraping.
🎯 Impact: Attackers or anomalous source data could cause the application to hang during regex parsing/type casting of excessively long strings or trigger unhandled logic errors via NaN/Inf manipulation.
🔧 Fix: Enforced string length bounds (50 characters) before conversion and added validation logic to reject `NaN`, `Inf`, and unreasonably large numbers.
✅ Verification: Ensure the new validations run against existing scraper tests via `uv run pytest tests/`.

---
*PR created automatically by Jules for task [2321263154461445505](https://jules.google.com/task/2321263154461445505) started by @partrita*