### PR TITLE
🛡️ Sentinel: Enforce strict connection timeouts for external data fetching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -56,3 +56,8 @@
 **Vulnerability:** Unbounded CLI parameters and potential for ZeroDivisionError in `optimal_threshold.py` and `backtest.py` via an initial investment <= 0 or extreme float ranges.
 **Learning:** External parameters, like CLI arguments, can be crafted to consume excessive memory or divide-by-zero, leading to application crashes.
 **Prevention:** Implement strict boundary checks on numeric inputs to prevent both memory exhaustion via unbounded arrays and fatal errors like ZeroDivisionError.
+
+## 2026-05-18 - [Security Enhancement] Enforce Strict Connection Timeouts
+**Vulnerability:** External data fetching used a single integer timeout (`timeout=10`) in `requests.get()`. This single value applies to both the connection phase and the read phase. A malicious or uncooperative server could act as a tarpit, accepting the TCP connection but never responding, tying up client resources for the full duration or longer if not carefully managed.
+**Learning:** Using a single timeout value in `requests` can lead to resource exhaustion if many connections hang during the initial handshake. Best practice dictates separating connection and read timeouts.
+**Prevention:** Always use a tuple for the `timeout` parameter (e.g., `timeout=(3.0, 10.0)`) to ensure the application fails fast if a connection cannot be quickly established, thereby preventing Denial of Service (DoS) via resource exhaustion.

--- a/src/kimchi_gold/price_fetcher.py
+++ b/src/kimchi_gold/price_fetcher.py
@@ -98,7 +98,9 @@ def extract_price_from_naver_finance(
     if not (hostname == "naver.com" or hostname.endswith(".naver.com")):
         raise ValueError(f"Invalid domain: {hostname}. Only naver.com and its subdomains are allowed.")
 
-    with requests.get(target_url, headers=REQUEST_HEADERS, timeout=10, allow_redirects=False, stream=True) as response:
+    # Security Enhancement: Separate connect and read timeouts (3.0s connect, 10.0s read)
+    # to prevent resource exhaustion from hanging connections (tarpits).
+    with requests.get(target_url, headers=REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True) as response:
         if response.is_redirect:
             raise ValueError("Redirects are not allowed for security reasons (SSRF bypass risk).")
         response.raise_for_status()  # Raise an exception for bad status codes

--- a/tests/test_now_price.py
+++ b/tests/test_now_price.py
@@ -33,7 +33,7 @@ def test_get_price_from_naver_success():
         price = price_fetcher.extract_price_from_naver_finance(url, error_msg)
         assert price == float(MOCK_DOMESTIC_PRICE_TEXT.replace(",", ""))
         mock_get.assert_called_once_with(
-            url, headers=price_fetcher.REQUEST_HEADERS, timeout=10, allow_redirects=False, stream=True
+            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True
         )
         mock_bs.assert_called_once_with(content, "html.parser")
         # class_ 파라미터가 람다 함수이므로 호출 여부만 확인
@@ -68,7 +68,7 @@ def test_get_price_from_naver_no_price_tag():
             price_fetcher.extract_price_from_naver_finance(url, error_msg)
         assert str(excinfo.value) == error_msg
         mock_get.assert_called_once_with(
-            url, headers=price_fetcher.REQUEST_HEADERS, timeout=10, allow_redirects=False, stream=True
+            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True
         )
         mock_bs.assert_called_once_with(content, "html.parser")
         # class_ 파라미터가 람다 함수이므로 호출 여부만 확인
@@ -103,7 +103,7 @@ def test_get_price_from_naver_no_price_in_text():
             price_fetcher.extract_price_from_naver_finance(url, error_msg)
         assert str(excinfo.value) == error_msg
         mock_get.assert_called_once_with(
-            url, headers=price_fetcher.REQUEST_HEADERS, timeout=10, allow_redirects=False, stream=True
+            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True
         )
         mock_bs.assert_called_once_with(content, "html.parser")
         # class_ 파라미터가 람다 함수이므로 호출 여부만 확인


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: External data fetching used a single integer timeout (`timeout=10`) which applies to both connection and read phases. This can lead to resource exhaustion if a malicious or uncooperative server acts as a tarpit, hanging during the initial TCP handshake.
🎯 Impact: An attacker could tie up system resources by causing connections to hang indefinitely.
🔧 Fix: Changed `timeout=10` to `timeout=(3.0, 10.0)` in `requests.get()` to explicitly enforce a strict 3-second connection timeout and a 10-second read timeout.
✅ Verification: Ran `uv run pytest tests/` to ensure tests continue to pass and `uv run ruff check` to confirm no linting errors. Updated test assertions to match the new tuple timeout.

---
*PR created automatically by Jules for task [14747394592653579409](https://jules.google.com/task/14747394592653579409) started by @partrita*