### PR TITLE
🛡️ Sentinel: [MEDIUM] Add `math.isfinite` validation to CLI float inputs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -61,3 +61,8 @@
 **Vulnerability:** External data fetching used a single integer timeout (`timeout=10`) in `requests.get()`. This single value applies to both the connection phase and the read phase. A malicious or uncooperative server could act as a tarpit, accepting the TCP connection but never responding, tying up client resources for the full duration or longer if not carefully managed.
 **Learning:** Using a single timeout value in `requests` can lead to resource exhaustion if many connections hang during the initial handshake. Best practice dictates separating connection and read timeouts.
 **Prevention:** Always use a tuple for the `timeout` parameter (e.g., `timeout=(3.0, 10.0)`) to ensure the application fails fast if a connection cannot be quickly established, thereby preventing Denial of Service (DoS) via resource exhaustion.
+
+## 2026-05-20 - [Security Enhancement] Enforce math.isfinite on Float CLI Parameters
+**Vulnerability:** Float CLI parameters (e.g., `min_threshold`, `max_threshold`, `buy_threshold`, `sell_threshold`) lacked `math.isfinite` validation. When passed non-finite values like `NaN` or `Inf`, the logic downstream produced erratic outcomes or application crashes (such as `ValueError: arange: cannot compute length` during sequence generation in `numpy`).
+**Learning:** Python's `float` type natively accepts `NaN` and `Inf`. When these values bypass initial validation and propagate to mathematical operations or sequence generators (like `numpy.arange`), they can lead to unhandled exceptions, logic errors, or DoS conditions.
+**Prevention:** Always validate user-provided float inputs using `math.isfinite()` to ensure they are concrete numeric values before executing dependent operations.

--- a/src/kimchi_gold/backtest.py
+++ b/src/kimchi_gold/backtest.py
@@ -227,6 +227,11 @@ def main():
         print("Error: Investment must be between 1 and 1,000,000,000.")
         sys.exit(1)
 
+    import math
+    if not math.isfinite(args.buy_threshold) or not math.isfinite(args.sell_threshold):
+        print("Error: Thresholds must be finite numbers.")
+        sys.exit(1)
+
     # Run backtest
     run_backtest(
         data,

--- a/src/kimchi_gold/optimal_threshold.py
+++ b/src/kimchi_gold/optimal_threshold.py
@@ -205,6 +205,10 @@ def main():
         print("Error: Step size must be a finite number greater than 0.")
         sys.exit(1)
 
+    if not math.isfinite(args.min_threshold) or not math.isfinite(args.max_threshold):
+        print("Error: Thresholds must be finite numbers.")
+        sys.exit(1)
+
     if args.min_threshold > args.max_threshold:
         print("Error: Minimum threshold cannot be greater than maximum threshold.")
         sys.exit(1)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Float CLI parameters (e.g., `min_threshold`, `max_threshold`, `buy_threshold`, `sell_threshold`) lacked validation to ensure they were concrete numeric values. Python natively accepts non-finite strings like `NaN` and `Inf` when parsing floats.
🎯 **Impact:** When `NaN` or `Inf` bypassed initial logic and propagated to downstream operations (like `numpy.arange` or mathematical thresholds), they could cause unhandled exceptions leading to application crashes (`ValueError: arange: cannot compute length`), unexpected backtest behavior, and potential DoS vectors. 
🔧 **Fix:** Implemented strict input validation using `math.isfinite()` on all critical float CLI variables across both `optimal_threshold.py` and `backtest.py`.
✅ **Verification:** Attempting to pass `NaN` or `Inf` via arguments like `--min-threshold NaN` or `--buy-threshold Inf` now cleanly exits the script with the descriptive message "Error: Thresholds must be finite numbers." and exits securely. Test suite passes successfully (`uv run pytest tests/`). 

Security learning logged to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12120693698281591129](https://jules.google.com/task/12120693698281591129) started by @partrita*