### PR TITLE
🛡️ Sentinel: [MEDIUM] Add explicit TLS verification explicitly

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -71,3 +71,7 @@ lidating the URL scheme (`https`) and domain is insufficient defense-in-depth, a
 **Vulnerability:** Raw exception messages (e.g., `collection_error`, `file_write_error`) were appended to user-facing `ValueError`, `IOError`, and `print()` statements in `price_fetcher.py` and `data_collector.py`.
 **Learning:** Exposing raw exceptions can inadvertently leak sensitive system information, such as file paths, internal logic states, or network configurations, aiding attackers in reconnaissance.
 **Prevention:** To prevent information leakage, securely log the raw exception details internally using a logging framework (`logger.error`), but raise or return generic, user-safe error messages (e.g., "시스템 로그를 확인해주세요.") to the end user.
+## 2026-05-21 - Explicitly Enforce TLS Verification
+**Vulnerability:** MitM vulnerability via disabled TLS verification
+**Learning:** Relying on default library parameters for critical security mechanisms leaves the application vulnerable if defaults are overridden (e.g., globally via env vars) or accidentally changed.
+**Prevention:** Explicitly specify security-critical parameters like `verify=True` in `requests` calls to ensure secure defaults are enforced.

--- a/src/kimchi_gold/price_fetcher.py
+++ b/src/kimchi_gold/price_fetcher.py
@@ -106,7 +106,7 @@ def extract_price_from_naver_finance(
 
     # Security Enhancement: Separate connect and read timeouts (3.0s connect, 10.0s read)
     # to prevent resource exhaustion from hanging connections (tarpits).
-    with requests.get(target_url, headers=REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True) as response:
+    with requests.get(target_url, headers=REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True, verify=True) as response:
         if response.is_redirect:
             logger.warning(f"[SECURITY] SSRF attempt blocked: Unexpected redirect encountered for {target_url}")
             raise ValueError("Redirects are not allowed for security reasons (SSRF bypass risk).")

--- a/src/kimchi_gold/price_fetcher.py
+++ b/src/kimchi_gold/price_fetcher.py
@@ -106,7 +106,14 @@ def extract_price_from_naver_finance(
 
     # Security Enhancement: Separate connect and read timeouts (3.0s connect, 10.0s read)
     # to prevent resource exhaustion from hanging connections (tarpits).
-    with requests.get(target_url, headers=REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True, verify=True) as response:
+    with requests.get(
+        target_url,
+        headers=REQUEST_HEADERS,
+        timeout=(3.0, 10.0),
+        allow_redirects=False,
+        stream=True,
+        verify=True,
+    ) as response:
         if response.is_redirect:
             logger.warning(f"[SECURITY] SSRF attempt blocked: Unexpected redirect encountered for {target_url}")
             raise ValueError("Redirects are not allowed for security reasons (SSRF bypass risk).")

--- a/tests/test_now_price.py
+++ b/tests/test_now_price.py
@@ -33,7 +33,7 @@ def test_get_price_from_naver_success():
         price = price_fetcher.extract_price_from_naver_finance(url, error_msg)
         assert price == float(MOCK_DOMESTIC_PRICE_TEXT.replace(",", ""))
         mock_get.assert_called_once_with(
-            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True
+            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True, verify=True
         )
         mock_bs.assert_called_once_with(content, "html.parser")
         # class_ 파라미터가 람다 함수이므로 호출 여부만 확인
@@ -68,7 +68,7 @@ def test_get_price_from_naver_no_price_tag():
             price_fetcher.extract_price_from_naver_finance(url, error_msg)
         assert str(excinfo.value) == error_msg
         mock_get.assert_called_once_with(
-            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True
+            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True, verify=True
         )
         mock_bs.assert_called_once_with(content, "html.parser")
         # class_ 파라미터가 람다 함수이므로 호출 여부만 확인
@@ -103,7 +103,7 @@ def test_get_price_from_naver_no_price_in_text():
             price_fetcher.extract_price_from_naver_finance(url, error_msg)
         assert str(excinfo.value) == error_msg
         mock_get.assert_called_once_with(
-            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True
+            url, headers=price_fetcher.REQUEST_HEADERS, timeout=(3.0, 10.0), allow_redirects=False, stream=True, verify=True
         )
         mock_bs.assert_called_once_with(content, "html.parser")
         # class_ 파라미터가 람다 함수이므로 호출 여부만 확인


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: Reliance on implicit secure defaults for TLS verification in HTTP calls.

🎯 **Impact**: If a developer or a misconfigured environment variable globally disables TLS verification, the `requests.get` call would become vulnerable to Man-in-the-Middle (MitM) attacks because the parameter was implicit.

🔧 **Fix**: Explicitly added `verify=True` to the `requests.get` call in `src/kimchi_gold/price_fetcher.py`. Also updated `test_now_price.py` mock assertions.

✅ **Verification**: Run `uv run pytest tests/` and verify all tests pass. This is a simple parameter enforcement and does not modify the application logic or create regressions.

---
*PR created automatically by Jules for task [7788220883167518876](https://jules.google.com/task/7788220883167518876) started by @partrita*