### PR TITLE
🛡️ Sentinel: [MEDIUM] Add job timeouts to GitHub Actions workflows

### DIFF
--- a/.github/workflows/Daily_collect.yml
+++ b/.github/workflows/Daily_collect.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   collect:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -20,6 +20,7 @@ jobs:
   publish:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -14,6 +14,7 @@ jobs:
   security:
     name: Run Bandit & pip-audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -94,7 +94,7 @@ lidating the URL scheme (`https`) and domain is insufficient defense-in-depth, a
 **Learning:** Directly printing absolute file paths to the console in CLI tools or scripts exposes internal system details (CWE-209), which could be useful to an attacker for reconnaissance.
 **Prevention:** Output only generic or relative filenames (e.g. `kimchi_gold_price_recent_12months.png`) to the user-facing console, while routing detailed internal context (like absolute file paths) to the logging framework using `logger.info()` for auditing purposes.
 
-## $(date +%Y-%m-%d) - [Add Workflow Timeouts]
+## YYYY-MM-DD - [Add Workflow Timeouts]
 **Vulnerability:** Missing timeout configurations in GitHub Actions workflows.
 **Learning:** Without explicit timeouts, compromised dependencies or malicious PRs can intentionally hang CI runners (e.g., infinite loops or cryptomining tarpits), exhausting the repository's GitHub Actions compute quota and causing a Denial of Service (DoS) for the CI/CD pipeline.
 **Prevention:** Always define a job-level `timeout-minutes` configuration (e.g., `timeout-minutes: 10`) in all GitHub Actions workflows to enforce strict execution time limits.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -93,3 +93,8 @@ lidating the URL scheme (`https`) and domain is insufficient defense-in-depth, a
 **Vulnerability:** The chart generator CLI script and library printed the absolute internal file paths of the generated charts directly to standard output upon success.
 **Learning:** Directly printing absolute file paths to the console in CLI tools or scripts exposes internal system details (CWE-209), which could be useful to an attacker for reconnaissance.
 **Prevention:** Output only generic or relative filenames (e.g. `kimchi_gold_price_recent_12months.png`) to the user-facing console, while routing detailed internal context (like absolute file paths) to the logging framework using `logger.info()` for auditing purposes.
+
+## $(date +%Y-%m-%d) - [Add Workflow Timeouts]
+**Vulnerability:** Missing timeout configurations in GitHub Actions workflows.
+**Learning:** Without explicit timeouts, compromised dependencies or malicious PRs can intentionally hang CI runners (e.g., infinite loops or cryptomining tarpits), exhausting the repository's GitHub Actions compute quota and causing a Denial of Service (DoS) for the CI/CD pipeline.
+**Prevention:** Always define a job-level `timeout-minutes` configuration (e.g., `timeout-minutes: 10`) in all GitHub Actions workflows to enforce strict execution time limits.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing timeout configurations in GitHub Actions workflows.
🎯 Impact: Without explicit timeouts, malicious PRs or compromised dependencies could intentionally hang the CI runner (e.g., infinite loops, cryptomining tarpits), causing Denial of Service (DoS) by exhausting the repository's GitHub Actions compute quota (the default limit is 6 hours).
🔧 Fix: Added `timeout-minutes: 10` to all jobs in all `.github/workflows/*.yml` files.
✅ Verification: Ensure workflows run successfully under normal operations and do not exceed 10 minutes.

---
*PR created automatically by Jules for task [909274414690602204](https://jules.google.com/task/909274414690602204) started by @partrita*